### PR TITLE
Update 0.6.23

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<38 or s390x]
+  skip: True  # [s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [s390x]
+  skip: True  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
@@ -45,7 +45,7 @@ test:
     - pptx.text
   requires:
     - pip
-    - behave >=1.2.5
+    # - behave >=1.2.5
     - mock >=1.0.1
     - pyparsing >=2.0.1
     - pytest >=2.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [s390x]
+  skip: True  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
@@ -25,7 +25,7 @@ requirements:
     - lxml >=3.1.0
     - pillow >=3.3.2
     - xlsxwriter >=0.5.7
-    
+
 test:
   source_files:
     - tests
@@ -61,11 +61,11 @@ about:
   license_family: MIT
   summary: Generate and manipulate Open XML PowerPoint (.pptx) files
   description: |
-    A typical use would be generating a PowerPoint presentation from dynamic content such as a database query, 
-    analytics output, or a JSON payload, perhaps in response to an HTTP request and downloading the generated 
+    A typical use would be generating a PowerPoint presentation from dynamic content such as a database query,
+    analytics output, or a JSON payload, perhaps in response to an HTTP request and downloading the generated
     PPTX file in response. It runs on any Python capable platform, including macOS and Linux, and does not require
     the PowerPoint application to be installed or licensed.
-  
+
   dev_url: https://github.com/scanny/python-pptx
   doc_url: https://python-pptx.readthedocs.io
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,8 @@ test:
     - pptx.text
   requires:
     - pip
+    # Behave is not available for py3.12 and requires an update
+    # to an outdated version of setuptools(<58)
     # - behave >=1.2.5
     - mock >=1.0.1
     - pyparsing >=2.0.1


### PR DESCRIPTION
## ☆Python-Pttx 0.6.23 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-4892)
[Upstream](https://github.com/scanny/python-pptx)
# Changes
This version on Pythpn-Pttx is rebuilt for public use on `defaults` per customer request
-  Removed `abs.yaml`
- `Behave` is a dependency that is not available for `Python 3.12` and requires an update to an outdated version of setuptools(<58). It was determined to not utilize this dependency.
- Add skip for `py<38`