### PR TITLE
python-pptx 0.6.23 [fix bump build number]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 587497ff28e779ab18dbb074f6d4052893c85dedc95ed75df319364f331fedee
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 


### PR DESCRIPTION
python-pptx 0.6.23

**Destination channel:** defaults

### Links

- [PKG-5241]
- dev_url (pypi): https://github.com/scanny/python-pptx/tree/v0.6.23
- conda-forge: https://github.com/conda-forge/python-pptx-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/python-pptx/0.6.23
- pypi inspector: https://inspector.pypi.io/project/python-pptx/0.6.23

### Explanation of changes:

- bump version number for `defaults`. See ticket.

### Notes for the reviewers

- the `abs.yaaml` was previously deleted, therefore this will be uploaded to `defaults` manually.
- after merging and uploading we need to delete the artifacts for the build number 0.

[PKG-5241]: https://anaconda.atlassian.net/browse/PKG-5241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ